### PR TITLE
Add extraction of liquid xp

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,6 +127,7 @@ jar {
         attr['FMLCorePlugin']               = mixin_loader_class
         attr['FMLCorePluginContainsFMLMod'] = 'true'
         attr['TweakClass']                  = 'org.spongepowered.asm.launch.MixinTweaker'
+        attr['ForceLoadAsMod'] = "true"
 
         def currentTasks = gradle.startParameter.taskNames
         if (currentTasks[0] == 'build' || currentTasks[0] == 'assemble')

--- a/src/main/java/furnacexpstorage/ConfigHandler.java
+++ b/src/main/java/furnacexpstorage/ConfigHandler.java
@@ -1,6 +1,10 @@
 package furnacexpstorage;
 
 import net.minecraftforge.common.config.Config;
+import net.minecraftforge.common.config.ConfigManager;
+import net.minecraftforge.fml.client.event.ConfigChangedEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 @Config(modid = FurnaceXPStorage.MODID)
 public class ConfigHandler {
@@ -21,5 +25,15 @@ public class ConfigHandler {
 		@Config.Comment("The conversion factor from xp to liquid xp")
 		@Config.Name("Conversion Factor")
 		public float conversionFactor = 0;
+	}
+
+	@Mod.EventBusSubscriber(modid = FurnaceXPStorage.MODID)
+	public static class EventHandler {
+		@SubscribeEvent
+		public static void onConfigChanged(ConfigChangedEvent.OnConfigChangedEvent event) {
+			if(event.getModID().equals(FurnaceXPStorage.MODID)) {
+				ConfigManager.sync(FurnaceXPStorage.MODID, Config.Type.INSTANCE);
+			}
+		}
 	}
 }

--- a/src/main/java/furnacexpstorage/ConfigHandler.java
+++ b/src/main/java/furnacexpstorage/ConfigHandler.java
@@ -7,4 +7,14 @@ public class ConfigHandler {
     @Config.Comment("Minecraft limits xp per smelted item to 1. Set to true to keep this behavior.")
     @Config.Name("Vanilla behavior: 1 xp per output item")
     public static boolean recreateVanillaLimit = true;
+
+	@Config.Comment("Configs for liquid xp to be extracted from the furnace")
+	public static XPConfig xpConfig = new XPConfig();
+	public static class XPConfig{
+		@Config.Comment("The fluid xp to be drained. Leave empty to disable")
+		public String fluid = "";
+
+		@Config.Comment("The conversion factor from xp to liquid xp")
+		public float conversionFactor = 0.0f;
+	}
 }

--- a/src/main/java/furnacexpstorage/ConfigHandler.java
+++ b/src/main/java/furnacexpstorage/ConfigHandler.java
@@ -8,13 +8,18 @@ public class ConfigHandler {
     @Config.Name("Vanilla behavior: 1 xp per output item")
     public static boolean recreateVanillaLimit = true;
 
-	@Config.Comment("Configs for liquid xp to be extracted from the furnace")
+	@Config.Comment("Configs for liquid xp to be extracted from furnaces")
+	@Config.Name("Fluid XP options")
 	public static XPConfig xpConfig = new XPConfig();
+
 	public static class XPConfig{
 		@Config.Comment("The fluid xp to be drained. Leave empty to disable")
-		public String fluid = "";
+		@Config.Name("Fluid Name")
+		@Config.RequiresMcRestart
+		public String fluidName = "";
 
 		@Config.Comment("The conversion factor from xp to liquid xp")
-		public float conversionFactor = 0.0f;
+		@Config.Name("Conversion Factor")
+		public float conversionFactor = 0;
 	}
 }

--- a/src/main/java/furnacexpstorage/FurnaceXPStorage.java
+++ b/src/main/java/furnacexpstorage/FurnaceXPStorage.java
@@ -26,8 +26,7 @@ public class FurnaceXPStorage {
 
 	@Mod.EventHandler
 	public static void onPreInit(FMLPreInitializationEvent event){
-		if(!ConfigHandler.xpConfig.fluid.isEmpty()){
+		if(!ConfigHandler.xpConfig.fluidName.isEmpty())
 			MinecraftForge.EVENT_BUS.register(AttachCapabilitiesHandler.class);
-		}
 	}
 }

--- a/src/main/java/furnacexpstorage/FurnaceXPStorage.java
+++ b/src/main/java/furnacexpstorage/FurnaceXPStorage.java
@@ -1,6 +1,9 @@
 package furnacexpstorage;
 
+import furnacexpstorage.handler.AttachCapabilitiesHandler;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -20,4 +23,11 @@ public class FurnaceXPStorage {
     public static final Random RAND = new Random();
     public static final Logger LOGGER = LogManager.getLogger(NAME);
     public static final String NBTKEY = "StoredXP";
+
+	@Mod.EventHandler
+	public static void onPreInit(FMLPreInitializationEvent event){
+		if(!ConfigHandler.xpConfig.fluid.isEmpty()){
+			MinecraftForge.EVENT_BUS.register(AttachCapabilitiesHandler.class);
+		}
+	}
 }

--- a/src/main/java/furnacexpstorage/compat/modcompat/BetterEndCompat.java
+++ b/src/main/java/furnacexpstorage/compat/modcompat/BetterEndCompat.java
@@ -1,10 +1,17 @@
 package furnacexpstorage.compat.modcompat;
 
 import mod.beethoven92.betterendforge.common.block.EndStoneSmelter;
+import mod.beethoven92.betterendforge.common.tileentity.EndStoneSmelterTileEntity;
 import net.minecraft.block.Block;
+import net.minecraft.tileentity.TileEntity;
 
 public class BetterEndCompat implements IFurnaceModCompat {
     public boolean isModFurnace(Block block){
         return block instanceof EndStoneSmelter;
     }
+
+	@Override
+	public boolean isModFurnace(TileEntity tile) {
+		return tile instanceof EndStoneSmelterTileEntity;
+	}
 }

--- a/src/main/java/furnacexpstorage/compat/modcompat/BetterEndCompat.java
+++ b/src/main/java/furnacexpstorage/compat/modcompat/BetterEndCompat.java
@@ -6,6 +6,7 @@ import net.minecraft.block.Block;
 import net.minecraft.tileentity.TileEntity;
 
 public class BetterEndCompat implements IFurnaceModCompat {
+	@Override
     public boolean isModFurnace(Block block){
         return block instanceof EndStoneSmelter;
     }

--- a/src/main/java/furnacexpstorage/compat/modcompat/BetterFurnacesReforgedCompat.java
+++ b/src/main/java/furnacexpstorage/compat/modcompat/BetterFurnacesReforgedCompat.java
@@ -6,6 +6,7 @@ import wily.betterfurnaces.blocks.BlockSmelting;
 import wily.betterfurnaces.tile.TileEntitySmeltingBase;
 
 public class BetterFurnacesReforgedCompat implements IFurnaceModCompat {
+	@Override
     public boolean isModFurnace(Block block){
         return block instanceof BlockSmelting;
     }

--- a/src/main/java/furnacexpstorage/compat/modcompat/BetterFurnacesReforgedCompat.java
+++ b/src/main/java/furnacexpstorage/compat/modcompat/BetterFurnacesReforgedCompat.java
@@ -1,10 +1,17 @@
 package furnacexpstorage.compat.modcompat;
 
 import net.minecraft.block.Block;
+import net.minecraft.tileentity.TileEntity;
 import wily.betterfurnaces.blocks.BlockSmelting;
+import wily.betterfurnaces.tile.TileEntitySmeltingBase;
 
 public class BetterFurnacesReforgedCompat implements IFurnaceModCompat {
     public boolean isModFurnace(Block block){
         return block instanceof BlockSmelting;
     }
+
+	@Override
+	public boolean isModFurnace(TileEntity tile) {
+		return tile instanceof TileEntitySmeltingBase;
+	}
 }

--- a/src/main/java/furnacexpstorage/compat/modcompat/BetterNetherCompat.java
+++ b/src/main/java/furnacexpstorage/compat/modcompat/BetterNetherCompat.java
@@ -1,10 +1,17 @@
 package furnacexpstorage.compat.modcompat;
 
 import net.minecraft.block.Block;
+import net.minecraft.tileentity.TileEntity;
 import paulevs.betternether.blocks.BlockCincinnasiteForge;
+import paulevs.betternether.tileentities.TileEntityForge;
 
 public class BetterNetherCompat implements IFurnaceModCompat {
     public boolean isModFurnace(Block block){
         return block instanceof BlockCincinnasiteForge;
     }
+
+	@Override
+	public boolean isModFurnace(TileEntity tile) {
+		return tile instanceof TileEntityForge;
+	}
 }

--- a/src/main/java/furnacexpstorage/compat/modcompat/BetterNetherCompat.java
+++ b/src/main/java/furnacexpstorage/compat/modcompat/BetterNetherCompat.java
@@ -6,6 +6,7 @@ import paulevs.betternether.blocks.BlockCincinnasiteForge;
 import paulevs.betternether.tileentities.TileEntityForge;
 
 public class BetterNetherCompat implements IFurnaceModCompat {
+	@Override
     public boolean isModFurnace(Block block){
         return block instanceof BlockCincinnasiteForge;
     }

--- a/src/main/java/furnacexpstorage/compat/modcompat/FurnaceOverhaulCompat.java
+++ b/src/main/java/furnacexpstorage/compat/modcompat/FurnaceOverhaulCompat.java
@@ -1,10 +1,17 @@
 package furnacexpstorage.compat.modcompat;
 
 import cazador.furnaceoverhaul.blocks.BlockIronFurnace;
+import cazador.furnaceoverhaul.tile.TileEntityIronFurnace;
 import net.minecraft.block.Block;
+import net.minecraft.tileentity.TileEntity;
 
 public class FurnaceOverhaulCompat implements IFurnaceModCompat {
     public boolean isModFurnace(Block block){
         return block instanceof BlockIronFurnace;
     }
+
+	@Override
+	public boolean isModFurnace(TileEntity tile) {
+		return tile instanceof TileEntityIronFurnace;
+	}
 }

--- a/src/main/java/furnacexpstorage/compat/modcompat/FurnaceOverhaulCompat.java
+++ b/src/main/java/furnacexpstorage/compat/modcompat/FurnaceOverhaulCompat.java
@@ -6,6 +6,7 @@ import net.minecraft.block.Block;
 import net.minecraft.tileentity.TileEntity;
 
 public class FurnaceOverhaulCompat implements IFurnaceModCompat {
+	@Override
     public boolean isModFurnace(Block block){
         return block instanceof BlockIronFurnace;
     }

--- a/src/main/java/furnacexpstorage/compat/modcompat/FurnusCompat.java
+++ b/src/main/java/furnacexpstorage/compat/modcompat/FurnusCompat.java
@@ -2,6 +2,7 @@ package furnacexpstorage.compat.modcompat;
 
 import mrriegel.furnus.init.ModBlocks;
 import mrriegel.furnus.tile.TileFurnus;
+import mrriegel.furnus.tile.TilePulvus;
 import net.minecraft.block.Block;
 import net.minecraft.tileentity.TileEntity;
 
@@ -13,6 +14,6 @@ public class FurnusCompat implements IFurnaceModCompat{
 
 	@Override
 	public boolean isModFurnace(TileEntity tile) {
-		return tile instanceof TileFurnus;
+		return tile instanceof TileFurnus || tile instanceof TilePulvus;
 	}
 }

--- a/src/main/java/furnacexpstorage/compat/modcompat/FurnusCompat.java
+++ b/src/main/java/furnacexpstorage/compat/modcompat/FurnusCompat.java
@@ -1,11 +1,18 @@
 package furnacexpstorage.compat.modcompat;
 
 import mrriegel.furnus.init.ModBlocks;
+import mrriegel.furnus.tile.TileFurnus;
 import net.minecraft.block.Block;
+import net.minecraft.tileentity.TileEntity;
 
 public class FurnusCompat implements IFurnaceModCompat{
     @Override
     public boolean isModFurnace(Block block) {
         return block == ModBlocks.furnus.getItemBlock().getBlock() || block == ModBlocks.pulvus.getItemBlock().getBlock();
     }
+
+	@Override
+	public boolean isModFurnace(TileEntity tile) {
+		return tile instanceof TileFurnus;
+	}
 }

--- a/src/main/java/furnacexpstorage/compat/modcompat/IFurnaceModCompat.java
+++ b/src/main/java/furnacexpstorage/compat/modcompat/IFurnaceModCompat.java
@@ -1,7 +1,10 @@
 package furnacexpstorage.compat.modcompat;
 
 import net.minecraft.block.Block;
+import net.minecraft.tileentity.TileEntity;
 
 public interface IFurnaceModCompat {
     boolean isModFurnace(Block block);
+
+	boolean isModFurnace(TileEntity tile);
 }

--- a/src/main/java/furnacexpstorage/compat/modcompat/IronFurnacesCompat.java
+++ b/src/main/java/furnacexpstorage/compat/modcompat/IronFurnacesCompat.java
@@ -1,7 +1,9 @@
 package furnacexpstorage.compat.modcompat;
 
 import com.xenomustache.ironfurnaces.blocks.*;
+import com.xenomustache.ironfurnaces.tileentity.*;
 import net.minecraft.block.Block;
+import net.minecraft.tileentity.TileEntity;
 
 public class IronFurnacesCompat implements IFurnaceModCompat {
     public boolean isModFurnace(Block block){
@@ -13,4 +15,15 @@ public class IronFurnacesCompat implements IFurnaceModCompat {
         if(block instanceof BlockShulkerFurnace) return true;
         return false;
     }
+
+	@Override
+	public boolean isModFurnace(TileEntity tile) {
+		if(tile instanceof TileEntityDiamondFurnace) return true;
+		if(tile instanceof TileEntityGlassFurnace) return true;
+		if(tile instanceof TileEntityGoldFurnace) return true;
+		if(tile instanceof TileEntityIronFurnace) return true;
+		if(tile instanceof TileEntityObsidianFurnace) return true;
+		if(tile instanceof TileEntityShulkerFurnace) return true;
+		return false;
+	}
 }

--- a/src/main/java/furnacexpstorage/compat/modcompat/IronFurnacesCompat.java
+++ b/src/main/java/furnacexpstorage/compat/modcompat/IronFurnacesCompat.java
@@ -6,6 +6,7 @@ import net.minecraft.block.Block;
 import net.minecraft.tileentity.TileEntity;
 
 public class IronFurnacesCompat implements IFurnaceModCompat {
+	@Override
     public boolean isModFurnace(Block block){
         if(block instanceof BlockDiamondFurnace) return true;
         if(block instanceof BlockGlassFurnace) return true;

--- a/src/main/java/furnacexpstorage/compat/modcompat/MoreFurnacesCompat.java
+++ b/src/main/java/furnacexpstorage/compat/modcompat/MoreFurnacesCompat.java
@@ -1,11 +1,19 @@
 package furnacexpstorage.compat.modcompat;
 
 import cubex2.mods.morefurnaces.blocks.BlockMoreFurnaces;
+import cubex2.mods.morefurnaces.tileentity.TileEntityIronFurnace;
 import net.minecraft.block.Block;
+import net.minecraft.tileentity.TileEntity;
 
 public class MoreFurnacesCompat implements IFurnaceModCompat{
     @Override
     public boolean isModFurnace(Block block) {
         return block instanceof BlockMoreFurnaces;
     }
+
+	@Override
+	public boolean isModFurnace(TileEntity tile) {
+		//All tileEntities from this mod extend TileEntityIronFurnace
+		return tile instanceof TileEntityIronFurnace;
+	}
 }

--- a/src/main/java/furnacexpstorage/compat/modcompat/MoreFurnaces_NE_Compat.java
+++ b/src/main/java/furnacexpstorage/compat/modcompat/MoreFurnaces_NE_Compat.java
@@ -1,11 +1,19 @@
 package furnacexpstorage.compat.modcompat;
 
 import dan.morefurnaces.blocks.BlockMoreFurnaces;
+import dan.morefurnaces.tileentity.TileEntityIronFurnace;
 import net.minecraft.block.Block;
+import net.minecraft.tileentity.TileEntity;
 
 public class MoreFurnaces_NE_Compat implements IFurnaceModCompat{
     @Override
     public boolean isModFurnace(Block block) {
         return block instanceof BlockMoreFurnaces;
     }
+
+	@Override
+	public boolean isModFurnace(TileEntity tile) {
+		//All tileEntities from this mod extend TileEntityIronFurnace
+		return tile instanceof TileEntityIronFurnace;
+	}
 }

--- a/src/main/java/furnacexpstorage/compat/modcompat/MysticalAgricultureCompat.java
+++ b/src/main/java/furnacexpstorage/compat/modcompat/MysticalAgricultureCompat.java
@@ -1,10 +1,17 @@
 package furnacexpstorage.compat.modcompat;
 
 import com.blakebr0.mysticalagriculture.blocks.furnace.BlockEssenceFurnace;
+import com.blakebr0.mysticalagriculture.tileentity.furnace.TileEssenceFurnace;
 import net.minecraft.block.Block;
+import net.minecraft.tileentity.TileEntity;
 
 public class MysticalAgricultureCompat implements IFurnaceModCompat {
     public boolean isModFurnace(Block block){
         return block instanceof BlockEssenceFurnace;
     }
+
+	@Override
+	public boolean isModFurnace(TileEntity tile) {
+		return tile instanceof TileEssenceFurnace;
+	}
 }

--- a/src/main/java/furnacexpstorage/compat/modcompat/MysticalAgricultureCompat.java
+++ b/src/main/java/furnacexpstorage/compat/modcompat/MysticalAgricultureCompat.java
@@ -6,6 +6,7 @@ import net.minecraft.block.Block;
 import net.minecraft.tileentity.TileEntity;
 
 public class MysticalAgricultureCompat implements IFurnaceModCompat {
+	@Override
     public boolean isModFurnace(Block block){
         return block instanceof BlockEssenceFurnace;
     }

--- a/src/main/java/furnacexpstorage/compat/modcompat/NuclearCraftCompat.java
+++ b/src/main/java/furnacexpstorage/compat/modcompat/NuclearCraftCompat.java
@@ -6,6 +6,7 @@ import net.minecraft.block.Block;
 import net.minecraft.tileentity.TileEntity;
 
 public class NuclearCraftCompat implements IFurnaceModCompat {
+	@Override
     public boolean isModFurnace(Block block){
         return block instanceof BlockNuclearFurnace;
     }

--- a/src/main/java/furnacexpstorage/compat/modcompat/NuclearCraftCompat.java
+++ b/src/main/java/furnacexpstorage/compat/modcompat/NuclearCraftCompat.java
@@ -1,10 +1,17 @@
 package furnacexpstorage.compat.modcompat;
 
 import nc.block.tile.processor.BlockNuclearFurnace;
+import nc.tile.processor.TileNuclearFurnace;
 import net.minecraft.block.Block;
+import net.minecraft.tileentity.TileEntity;
 
 public class NuclearCraftCompat implements IFurnaceModCompat {
     public boolean isModFurnace(Block block){
         return block instanceof BlockNuclearFurnace;
     }
+
+	@Override
+	public boolean isModFurnace(TileEntity tile) {
+		return tile instanceof TileNuclearFurnace;
+	}
 }

--- a/src/main/java/furnacexpstorage/handler/AttachCapabilitiesHandler.java
+++ b/src/main/java/furnacexpstorage/handler/AttachCapabilitiesHandler.java
@@ -1,0 +1,114 @@
+package furnacexpstorage.handler;
+
+import furnacexpstorage.ConfigHandler;
+import furnacexpstorage.FurnaceXPStorage;
+import furnacexpstorage.compat.CompatHandler;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.tileentity.TileEntityFurnace;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.event.AttachCapabilitiesEvent;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidRegistry;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
+import net.minecraftforge.fluids.capability.FluidTankProperties;
+import net.minecraftforge.fluids.capability.IFluidHandler;
+import net.minecraftforge.fluids.capability.IFluidTankProperties;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class AttachCapabilitiesHandler {
+	//Only listens if allowed
+	@SubscribeEvent
+	public static void onAttackCapabilities(AttachCapabilitiesEvent<TileEntity> event){
+		FurnaceXPStorage.LOGGER.info("AttachCapabilitiesEvent is fired for {}", event.getObject().getClass().getSimpleName());
+		if(isFurnaceTile(event.getObject())){
+			event.addCapability(new ResourceLocation(FurnaceXPStorage.MODID, "xp"), new ICapabilityProvider() {
+				@Override
+				public boolean hasCapability(@Nonnull Capability<?> capability, @Nullable EnumFacing enumFacing) {
+					return capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY;
+				}
+
+				@Nullable
+				@Override
+				@SuppressWarnings("unchecked")
+				public <T> T getCapability(@Nonnull Capability<T> capability, @Nullable EnumFacing enumFacing) {
+					if(capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY){
+						return (T) new FurnaceXPCapability(event.getObject());
+					}
+					return null;
+				}
+			});
+		}
+	}
+
+	public static class FurnaceXPCapability implements IFluidHandler {
+		public static Fluid xpFluid = FluidRegistry.getFluid(ConfigHandler.xpConfig.fluid);
+
+		public TileEntity tile;
+
+		public FurnaceXPCapability(TileEntity tile){
+			this.tile = tile;
+		}
+		@Override
+		public IFluidTankProperties[] getTankProperties() {
+			return new FluidTankProperties[]{new FluidTankProperties(
+				new FluidStack(xpFluid, (int)(ConfigHandler.xpConfig.conversionFactor*tile.getTileData().getFloat(FurnaceXPStorage.NBTKEY))),
+				Integer.MAX_VALUE,
+				false,
+				true
+			)};
+		}
+
+		@Override
+		public int fill(FluidStack fluidStack, boolean b) {
+			return 0;
+		}
+
+		@Nullable
+		@Override
+		public FluidStack drain(FluidStack fluidStack, boolean doDrain) {
+			if(fluidStack.getFluid() == xpFluid){
+				return drain(fluidStack.amount, doDrain);
+			}
+			return null;
+		}
+
+		@Nullable
+		@Override
+		public FluidStack drain(int requested, boolean doDrain) {
+			float stored = tile.getTileData().getFloat(FurnaceXPStorage.NBTKEY);
+			//
+			int drained = Math.min(requested, (int)(ConfigHandler.xpConfig.conversionFactor*stored));
+			if(drained == 0){
+				return null;
+			}
+			if(doDrain){
+				tile.getTileData().setFloat(FurnaceXPStorage.NBTKEY, stored - drained/ConfigHandler.xpConfig.conversionFactor);
+				tile.markDirty();
+			}
+			return new FluidStack(xpFluid, drained);
+		}
+	}
+
+	private static boolean isFurnaceTile(TileEntity tile){
+		if (tile instanceof TileEntityFurnace) return true; //includes betterendforge EndFurnace, betterwithmods, fastfurnace, nethercraft
+
+		if (CompatHandler.isModLoaded("betterendforge") && CompatHandler.getHandler("betterendforge", true).isModFurnace(tile)) return true;
+		if (CompatHandler.isModLoaded("betterfurnacesreforged") && CompatHandler.getHandler("betterfurnacesreforged", true).isModFurnace(tile)) return true;
+		if (CompatHandler.isModLoaded("betternether") && CompatHandler.getHandler("betternether", true).isModFurnace(tile)) return true;
+		if (CompatHandler.isModLoaded("furnaceoverhaul") && CompatHandler.getHandler("furnaceoverhaul", true).isModFurnace(tile)) return true;
+		if (CompatHandler.isModLoaded("furnus") && CompatHandler.getHandler("furnus", true).isModFurnace(tile)) return true;
+		if (CompatHandler.isModLoaded("ironfurnaces") && CompatHandler.getHandler("ironfurnaces", true).isModFurnace(tile)) return true;
+		if (CompatHandler.isModLoaded("morefurnaces") && CompatHandler.getHandler("morefurnaces", false).isModFurnace(tile)) return true;
+		if (CompatHandler.isModLoaded("morefurnaces") && CompatHandler.getHandler("morefurnaces", true).isModFurnace(tile)) return true;
+		if (CompatHandler.isModLoaded("mysticalagriculture") && CompatHandler.getHandler("mysticalagriculture", true).isModFurnace(tile)) return true;
+		if (CompatHandler.isModLoaded("nuclearcraft") && CompatHandler.getHandler("nuclearcraft", true).isModFurnace(tile)) return true;
+		return false;
+	}
+}

--- a/src/main/java/furnacexpstorage/handler/AttachCapabilitiesHandler.java
+++ b/src/main/java/furnacexpstorage/handler/AttachCapabilitiesHandler.java
@@ -26,7 +26,6 @@ public class AttachCapabilitiesHandler {
 	//Only listens if allowed
 	@SubscribeEvent
 	public static void onAttackCapabilities(AttachCapabilitiesEvent<TileEntity> event){
-		FurnaceXPStorage.LOGGER.info("AttachCapabilitiesEvent is fired for {}", event.getObject().getClass().getSimpleName());
 		if(isFurnaceTile(event.getObject())){
 			event.addCapability(new ResourceLocation(FurnaceXPStorage.MODID, "xp"), new ICapabilityProvider() {
 				@Override
@@ -48,7 +47,7 @@ public class AttachCapabilitiesHandler {
 	}
 
 	public static class FurnaceXPCapability implements IFluidHandler {
-		public static Fluid xpFluid = FluidRegistry.getFluid(ConfigHandler.xpConfig.fluid);
+		public static Fluid xpFluid = FluidRegistry.getFluid(ConfigHandler.xpConfig.fluidName);
 
 		public TileEntity tile;
 
@@ -73,9 +72,7 @@ public class AttachCapabilitiesHandler {
 		@Nullable
 		@Override
 		public FluidStack drain(FluidStack fluidStack, boolean doDrain) {
-			if(fluidStack.getFluid() == xpFluid){
-				return drain(fluidStack.amount, doDrain);
-			}
+			if(fluidStack.getFluid() == xpFluid) return drain(fluidStack.amount, doDrain);
 			return null;
 		}
 
@@ -83,11 +80,10 @@ public class AttachCapabilitiesHandler {
 		@Override
 		public FluidStack drain(int requested, boolean doDrain) {
 			float stored = tile.getTileData().getFloat(FurnaceXPStorage.NBTKEY);
-			//
+
 			int drained = Math.min(requested, (int)(ConfigHandler.xpConfig.conversionFactor*stored));
-			if(drained == 0){
-				return null;
-			}
+			if(drained == 0) return null;
+
 			if(doDrain){
 				tile.getTileData().setFloat(FurnaceXPStorage.NBTKEY, stored - drained/ConfigHandler.xpConfig.conversionFactor);
 				tile.markDirty();


### PR DESCRIPTION
Allows furnace's internal XP to be extracted as a fluid. The fluid and conversion ratios are configurable

The configs are added to ConfigHandler.java. By default, the fluid is empty, which is interpreted as the xp extraction being disabled (See FurnaceXPStorage). The intent is that packmakers choose which liquid XP they want to use, given their pack already has one.

To do so, the mod listens to AttachCapabilitiesEvent for TileEntities and adds a fluid container capability (extract-only) whose content is proportional to the stored XP amount (read and written every time the fluid capability is called). See handlers/AttachCapabilityHandler

Finally, I had to add a method to IFurnaceModCompat for matching TileEntities, as there is no way to get a Block from a Tile in AttachCapabilitiesEvent. This tile handler could be used instead of the block matcher in BlockBreakHandler, but this is not implemented in this PR. Most files changed are the implementations of IFurnaceModCompat that now have compatibility for liquid xp

Example with pulling Thermal Expansion liquid XP and pipes (should support all fluids and pipes):
<img width="1854" height="1011" alt="2025-12-13_13 05 46" src="https://github.com/user-attachments/assets/d356b88a-6daf-4e8a-bfe0-342dbd3392cd" />
